### PR TITLE
[fix] fixes some minor issues with forward_ticket and forward_ticket_comment

### DIFF
--- a/fns/forward_ticket.sql
+++ b/fns/forward_ticket.sql
@@ -1,11 +1,12 @@
-Create or replace function spawn_ticket(from_staff uuid, to_staff uuid)
+Create or replace function forward_ticket(ticket_id uuid, from_staff uuid, to_staff uuid)
 returns void as $$
 begin
-insert into public.ticket_interaction_history (ticket_id, action, note) VALUES (ticket_id, 'forward', 'Forwarded from ' + from_staff + ' to ' + to_staff);
+insert into public.ticket_interaction_history (ticket_id, action, note, by) VALUES (ticket_id, 'forward', 'Forwarded from ' || from_staff || ' to ' || to_staff, auth.uid());
 
-update public.ticket
-set assigned_to = to_staff
-where assigned_to = from_staff;
+UPDATE public.ticket
+SET assigned_to = to_staff
+WHERE ticket.ticket_id = forward_ticket.ticket_id
+AND assigned_to = from_staff;
 
 end;
 $$ language plpgsql;

--- a/fns/forward_ticket_comment.sql
+++ b/fns/forward_ticket_comment.sql
@@ -1,11 +1,12 @@
-CREATE OR REPLACE FUNCTION public.forward_ticket(from_staff UUID, to_staff UUID, note TEXT)
+CREATE OR REPLACE FUNCTION forward_ticket_comment(ticket_id uuid, from_staff UUID, to_staff UUID, note TEXT)
 RETURNS VOID AS $$
 BEGIN
-    INSERT INTO public.ticket_interaction_history (ticket_id, action, note)
-    VALUES (ticket_id, 'forward', 'Forwarded from ' || from_staff || ' to ' || to_staff || '.\nComment: ' || note);
+    INSERT INTO public.ticket_interaction_history (ticket_id, action, note, by)
+    VALUES (ticket_id, 'forward', 'Forwarded from ' || from_staff || ' to ' || to_staff || '.\nComment: ' || note, auth.uid());
     
     UPDATE public.ticket
     SET assigned_to = to_staff
-    WHERE assigned_to = from_staff;
+    WHERE ticket.ticket_id = forward_ticket.ticket_id
+    AND assigned_to = from_staff;
 END;
 $$ LANGUAGE plpgsql;


### PR DESCRIPTION
`[feat/fix/refactor] fixes some minor issues with forward_ticket and forward_ticket_comment`

## What? 
- Added "by" in the insert.
- Correctly name the functions.
- Adjust the logic of the update.

## Why?
- To make it runnable and be suitable for the project.

## How?
- Changed functions name from "spawn_ticket" to "forward_ticket", "forward_ticket" to "forward_ticket_comment".
- Added ticket_id in the parameters.
- Added by in the insert to address the person who made the change.
- Adjusted the logic so that it only update specific tickets, not all the tickets that the original staff was assigned to.
