### PR TITLE
[feat/fix/refactor] Add functions for updating appointment and ticket interaction history

### DIFF
--- a/fns/editInteractionHistory.sql
+++ b/fns/editInteractionHistory.sql
@@ -1,0 +1,11 @@
+CREATE OR REPLACE FUNCTION editInteractionHistory(
+    uid integer,
+    note text
+)
+RETURNS VOID AS $$
+BEGIN
+    UPDATE ticket_interaction_history history
+    SET history.note = note
+    WHERE history.id = uid;
+END;
+$$ LANGUAGE plpgsql;

--- a/fns/updateAppointmentDoctor.sql
+++ b/fns/updateAppointmentDoctor.sql
@@ -19,7 +19,7 @@ BEGIN
     VALUES (
         ticket_id_temp, 
         now(),
-        'comment'::ticket_interaction_type, 
+        'appointment_update'::ticket_interaction_type, 
         'Doctor update changed from ' || old_staff_id || ' to ' || staff_id || ' for appointment ' || id, 
         auth.uid()
     );

--- a/fns/updateAppointmentDoctor.sql
+++ b/fns/updateAppointmentDoctor.sql
@@ -1,0 +1,11 @@
+CREATE OR REPLACE FUNCTION updateAppointmentDoctor(
+    id uuid,
+    staff_id uuid
+)
+RETURNS VOID AS $$
+BEGIN
+    UPDATE Appointment apt
+    SET apt.staff_id = staff_id
+    WHERE apt.appointment_id = id;
+END;
+$$ LANGUAGE plpgsql;

--- a/fns/updateAppointmentDoctor.sql
+++ b/fns/updateAppointmentDoctor.sql
@@ -3,9 +3,25 @@ CREATE OR REPLACE FUNCTION updateAppointmentDoctor(
     staff_id uuid
 )
 RETURNS VOID AS $$
+DECLARE 
+    ticket_id_temp uuid;
+    old_staff_id uuid;
 BEGIN
+    SELECT apt.ticket_id, apt.staff_id INTO ticket_id_temp, old_staff_id
+    FROM Appointment apt
+    WHERE apt.appointment_id = id;
+
     UPDATE Appointment apt
     SET apt.staff_id = staff_id
     WHERE apt.appointment_id = id;
+
+    INSERT INTO ticket_interaction_history (ticket_id, time, action, note, by)
+    VALUES (
+        ticket_id_temp, 
+        now(),
+        'comment'::ticket_interaction_type, 
+        'Doctor update changed from ' || old_staff_id || ' to ' || staff_id || ' for appointment ' || id, 
+        auth.uid()
+    );
 END;
 $$ LANGUAGE plpgsql;

--- a/fns/updateAppointmentStatus.sql
+++ b/fns/updateAppointmentStatus.sql
@@ -19,7 +19,7 @@ BEGIN
     VALUES (
         ticket_id_temp, 
         now(),
-        'comment'::ticket_interaction_type, 
+        'appointment_update'::ticket_interaction_type, 
         'Status update changed from ' || old_status || ' to ' || status || ' for appointment ' || id, 
         auth.uid()
     );

--- a/fns/updateAppointmentStatus.sql
+++ b/fns/updateAppointmentStatus.sql
@@ -1,0 +1,11 @@
+CREATE OR REPLACE FUNCTION updateAppointmentStatus(
+    id uuid,
+    status apt_status
+)
+RETURNS VOID AS $$
+BEGIN
+    UPDATE Appointment apt
+    SET apt.status = status
+    WHERE apt.appointment_id = id;
+END;
+$$ LANGUAGE plpgsql;

--- a/fns/updateAppointmentStatus.sql
+++ b/fns/updateAppointmentStatus.sql
@@ -3,9 +3,25 @@ CREATE OR REPLACE FUNCTION updateAppointmentStatus(
     status apt_status
 )
 RETURNS VOID AS $$
+DECLARE 
+    ticket_id_temp uuid;
+    old_status apt_status;
 BEGIN
+    SELECT apt.ticket_id, apt.status INTO ticket_id_temp, old_status
+    FROM Appointment apt
+    WHERE apt.appointment_id = id;
+
     UPDATE Appointment apt
     SET apt.status = status
     WHERE apt.appointment_id = id;
+
+    INSERT INTO ticket_interaction_history (ticket_id, time, action, note, by)
+    VALUES (
+        ticket_id_temp, 
+        now(),
+        'comment'::ticket_interaction_type, 
+        'Status update changed from ' || old_status || ' to ' || status || ' for appointment ' || id, 
+        auth.uid()
+    );
 END;
 $$ LANGUAGE plpgsql;

--- a/fns/updateAppointmentVisibility.sql
+++ b/fns/updateAppointmentVisibility.sql
@@ -18,7 +18,7 @@ BEGIN
     VALUES (
         ticket_id_temp, 
         now(),
-        'comment'::ticket_interaction_type, 
+        'appointment_update'::ticket_interaction_type, 
         'Visibility update changed to ' || status || ' for appointment ' || id, 
         auth.uid()
     );

--- a/fns/updateAppointmentVisibility.sql
+++ b/fns/updateAppointmentVisibility.sql
@@ -3,9 +3,24 @@ CREATE OR REPLACE FUNCTION updateAppointmentVisibility(
     isPublic boolean
 )
 RETURNS VOID AS $$
+DECLARE 
+    ticket_id_temp uuid;
 BEGIN
-    UPDATE Appointment apt
-    SET apt.isPublic = isPublic
+    SELECT apt.ticket_id INTO ticket_id_temp
+    FROM Appointment apt
     WHERE apt.appointment_id = id;
+
+    UPDATE Appointment apt
+    SET apt.visibility = isPublic
+    WHERE apt.appointment_id = id;
+
+    INSERT INTO ticket_interaction_history (ticket_id, time, action, note, by)
+    VALUES (
+        ticket_id_temp, 
+        now(),
+        'comment'::ticket_interaction_type, 
+        'Visibility update changed to ' || status || ' for appointment ' || id, 
+        auth.uid()
+    );
 END;
 $$ LANGUAGE plpgsql;

--- a/fns/updateAppointmentVisibility.sql
+++ b/fns/updateAppointmentVisibility.sql
@@ -1,0 +1,11 @@
+CREATE OR REPLACE FUNCTION updateAppointmentVisibility(
+    id uuid,
+    isPublic boolean
+)
+RETURNS VOID AS $$
+BEGIN
+    UPDATE Appointment apt
+    SET apt.isPublic = isPublic
+    WHERE apt.appointment_id = id;
+END;
+$$ LANGUAGE plpgsql;

--- a/fns/updateTicketStatus.sql
+++ b/fns/updateTicketStatus.sql
@@ -1,24 +1,3 @@
--- Policy: Only assigned staff can update table ticket
-CREATE POLICY "staffUpdateTicket_policy" ON public.ticket
-FOR UPDATE 
-TO authenticated
-USING (
-    assigned_to IN (
-        SELECT staff_id 
-        FROM staff 
-        WHERE account_uid = auth.uid() 
-        AND status = true
-    )
-)
-WITH CHECK (
-    assigned_to IN (
-        SELECT staff_id 
-        FROM staff 
-        WHERE account_uid = auth.uid() 
-        AND status = true
-    )
-);
-
 CREATE OR REPLACE FUNCTION public.updateTicketStatus(
     ticket_id UUID,
     new_status tik_status

--- a/policy/staff_update_ticket.sql
+++ b/policy/staff_update_ticket.sql
@@ -1,0 +1,11 @@
+CREATE POLICY "staff_can_update_ticket" ON public.ticket
+FOR UPDATE 
+TO authenticated
+USING (
+    assigned_to IN (
+        SELECT staff_id 
+        FROM staff 
+        WHERE account_uid = auth.uid() 
+        AND status = true
+    )
+);


### PR DESCRIPTION
`[feat/fix/refactor] Add functions for updating appointment and ticket interaction history`

This PR is linked with issue #22 and half of #24 

## What? 
- `editInteractionHistory`: Updates the note field in the ticket_interaction_history table for a specific interaction.
- `updateAppointmentDoctor`: Reassigns the doctor for a given appointment.
- `updateAppointmentStatus`: Updates the status of an appointment.
- `updateAppointmentVisibility`: Updates the visibility of an appointment.
- `UpdateTicketStatus`: Moved the policy written in the same file as the function.

## Why?
- Better management of appointments.

## How?
- `editInteractionHistory`: Updates the note field in the ticket_interaction_history table for a given interaction ID (integer).
- `updateAppointmentDoctor`: Updates the staff_id in the Appointment table for a specified appointment_id.
- `updateAppointmentStatus`: Updates the status field in the Appointment table.
- `updateAppointmentVisibility`: Updates the visibility field in the Appointment table.
- `updateTicketStatus`: Moved the policy that was written alongside the function to the `Policy` folder.
