### PR TITLE
[feat] Update functions for Appointment

### DIFF
--- a/fns/update_appointment_content.sql
+++ b/fns/update_appointment_content.sql
@@ -1,0 +1,28 @@
+create or replace function update_appointment_content(id_to_update uuid, new_content text)
+returns void as 
+
+$$
+declare 
+    temp_ticket_id uuid;
+begin
+--modify the required field in appointment table
+    update Appointment apt 
+    set apt.content = new_content
+    where apt.appointment_id = id_to_update;
+-- get the corresponding ticket
+    select apt.ticket_id
+    from Appointment apt 
+    where apt.appointment_id = id_to_update
+    into temp_ticket_id;
+--update corresponding ticket interaction history
+    insert into Ticket_interaction_history(ticket_id, time, action, note, "by")
+    values (
+        temp_ticket_id,
+        now(),
+        'comment',
+        format('Updated appointment id: %s  with new content: %s', id_to_update::text, new_content),  -- format note for readability
+        current_setting('jwt.claim.user_id')::uuid                                                  -- this takes the id of the logged in user who is the modifier
+    );
+end;
+$$
+language plpgsql;

--- a/fns/update_appointment_duration.sql
+++ b/fns/update_appointment_duration.sql
@@ -1,0 +1,28 @@
+create or replace function update_appointment_duration(id_to_update uuid, new_duration integer)
+returns void as 
+
+$$
+declare 
+    temp_ticket_id uuid;
+begin
+-- update required field in appointment table
+    update Appointment apt 
+    set apt.duration = new_duration
+    where apt.appointment_id = id_to_update;
+-- get the corresponding ticket
+    select apt.ticket_id
+    from Appointment apt 
+    where apt.appointment_id = id_to_update
+    into temp_ticket_id;
+--update corresponding ticket interaction history
+    insert into Ticket_interaction_history(ticket_id, time, action, note, "by")
+    values (
+        temp_ticket_id,
+        now(),
+        'comment',
+        format('Updated appointment id: %s  with new duration: %s', id_to_update::text, new_duration),    -- format for readability
+        current_setting('jwt.claim.user_id')::uuid                                                      -- this takes id from user who logged in
+    );
+end;
+$$
+language plpgsql;

--- a/fns/update_appointment_time.sql
+++ b/fns/update_appointment_time.sql
@@ -1,0 +1,28 @@
+create or replace function update_appointment_meeting_time(id_to_update uuid, new_meeting_time timestamptz)
+returns void as
+ 
+ $$
+ declare 
+    temp_ticket_id uuid;
+ begin
+ -- update required field in appointment table
+    update Appointment apt
+    set apt.meeting_date = new_meeting_time
+    where apt.appointment_id = id_to_update;
+-- get the corresponding ticket
+    select apt.ticket_id
+    from Appointment apt 
+    where apt.appointment_id = id_to_update
+    into temp_ticket_id;
+--update corresponding ticket interaction history
+    insert into Ticket_interaction_history(ticket_id, time, action, note, "by")
+    values (
+        temp_ticket_id,
+        now(),
+        'comment',
+        format('Updated appointment id: %s  with new meeting time: %L', id_to_update::text, new_meeting_time),
+        current_setting('jwt.claim.user_id')::uuid
+    );
+end;
+ $$
+ language plpgsql;


### PR DESCRIPTION
[feat] Update for issue #24 
Added 3 of 6 functions (first 2 function in the description)
1. update_appointment_time() returns void
2. update_appointment_duration() returns void
3. update_appointment_content() returns void

All functions takes parameter as mentioned in the issue description.
All functions interact with table ticket_interaction_history to record changes
None of the function raise notification