### PR TITLE
[refactor] Renamed create appointment and added needed fields.

### DIFF
--- a/fns/createAppointment.sql
+++ b/fns/createAppointment.sql
@@ -1,33 +1,25 @@
-CREATE OR REPLACE FUNCTION public.createAppointment(
+CREATE OR REPLACE FUNCTION public.create_appointment(
   p_duration INTEGER,
   p_meeting_date TIMESTAMPTZ,
   p_isPublic BOOLEAN,
   p_requested_doctor UUID,
-  p_patient UUID
+  p_service_description text,
+  p_phone TEXT,
 )
 RETURNS UUID AS $$
 DECLARE
   v_appointment_id UUID;
   v_ticket_content TEXT;
-  v_response JSONB;
-  v_supabase_url TEXT := 'https://ejfeybaktdorddskajzc.supabase.co';
+
 BEGIN
   -- Create ticket content with newlines
   v_ticket_content := format(
-    'Overview: Confirm patient information\nPlease confirm patient following information, by phone at number +849012345678.\n- Service: HIV treatment advisory appointment\n- Time: %s\n- Doctor: <Any doctor would be OK>\nThank you\nHaivy Limited Company.',
-    to_char(p_meeting_date, 'Mon DD, YYYY - HH24:MI')
-  );
-
-  -- Call create_ticket edge function
-  SELECT content::jsonb INTO v_response
-  FROM http_post(
-    v_supabase_url || '/functions/v1/create_ticket',
-    jsonb_build_object(
-      'ticket_sender', 'system', --not being used by the edge function
-      'ticket_overview', 'Confirm patient information',
-      'ticket_content', v_ticket_content
-    )::text,
-    'application/json'
+    'Please confirm patient information by phone at number: %s.
+    - Service: %s
+    Thank you,
+    Haivy Limited Company.',
+    p_phone,
+    p_service_description
   );
 
   -- Insert appointment with ticket_id
@@ -37,8 +29,6 @@ BEGIN
     visibility,
     staff_id,
     patient_uid,
-    status,
-    created_date,
     ticket_id
   ) VALUES (
     p_duration,
@@ -46,9 +36,7 @@ BEGIN
     p_isPublic,
     p_requested_doctor,
     p_patient,
-    'pending'::apt_status,
-    NOW(),
-    (v_response->'data'->>'ticketId')::UUID
+    create_ticket('Confirm appointment information',v_ticket_content, 'appointment'::ticket_type)
   ) RETURNING appointment_id INTO v_appointment_id;
 
   RETURN v_appointment_id;

--- a/fns/dimiss_ticket.sql
+++ b/fns/dimiss_ticket.sql
@@ -5,7 +5,7 @@ CREATE OR REPLACE FUNCTION public.dismiss_ticket(
 )
 RETURNS VOID AS $$
 DECLARE
-    current_user_id UUID;
+
     ticket_exists BOOLEAN;
 BEGIN
     -- Update the ticket status


### PR DESCRIPTION
## What?
Refactored the createAppointment logic to follow the new naming scheme and added the necessary fields to support updated appointment creation requirements.

## Why?
To ensure consistency across the codebase and to accommodate data requirements for appointment records.