### PR TITLE
[feat] Added Medicine CRUD and related Policies

### DIFF
--- a/fns/add_medication.sql
+++ b/fns/add_medication.sql
@@ -1,0 +1,22 @@
+CREATE OR REPLACE FUNCTION add_medication(
+    med_name varchar,
+    med_description text,
+    med_availability boolean,
+    med_time medicine_timing
+)
+RETURNS VOID AS $$
+BEGIN
+    INSERT INTO Medicine (
+        name, 
+        description, 
+        is_available, 
+        med_time
+    )
+    VALUES (
+        med_name, 
+        med_description, 
+        med_availability, 
+        med_time
+    );
+END;
+$$ LANGUAGE plpgsql;

--- a/fns/delete_medicine.sql
+++ b/fns/delete_medicine.sql
@@ -1,0 +1,10 @@
+CREATE OR REPLACE FUNCTION delete_medicine(
+    med_id uuid
+)
+RETURNS VOID AS $$
+BEGIN
+    UPDATE Medicine m
+    SET m.is_available = FALSE
+    WHERE medicine_id = med_id;
+END;
+$$ LANGUAGE plpgsql;

--- a/fns/delete_medicine.sql
+++ b/fns/delete_medicine.sql
@@ -1,4 +1,4 @@
-CREATE OR REPLACE FUNCTION delete_medicine(
+CREATE OR REPLACE FUNCTION delete_medication(
     med_id uuid
 )
 RETURNS VOID AS $$

--- a/fns/get_medicine_info.sql
+++ b/fns/get_medicine_info.sql
@@ -1,0 +1,19 @@
+CREATE OR REPLACE FUNCTION get_medication_info(
+        med_id uuid
+) 
+RETURNS JSON AS $$ 
+DECLARE
+        result json;
+BEGIN
+        SELECT json_build_object(
+                'name', m.name,
+                'description', m.description,
+                'is_available', m.is_available,
+                'med_time', m.med_time
+        ) INTO result
+        FROM medicine m
+        WHERE m.medicine_id = med_id;
+
+        RETURN result;
+END;
+$$ LANGUAGE plpgsql;

--- a/fns/update_medicine_info.sql
+++ b/fns/update_medicine_info.sql
@@ -1,0 +1,18 @@
+CREATE OR REPLACE FUNCTION update_medicine(
+    med_id uuid,
+    med_name varchar,
+    med_description text,
+    med_availability boolean,
+    med_time medicine_timing
+)
+RETURNS VOID AS $$
+BEGIN
+    UPDATE Medicine m
+    SET 
+        m.name = med_name,
+        m.description = med_description,
+        m.is_available = med_availability,
+        m.med_time = med_time
+    WHERE m.medicine_id = med_id;
+END;
+$$ LANGUAGE plpgsql;

--- a/fns/update_medicine_info.sql
+++ b/fns/update_medicine_info.sql
@@ -1,4 +1,4 @@
-CREATE OR REPLACE FUNCTION update_medicine(
+CREATE OR REPLACE FUNCTION update_medication_info(
     med_id uuid,
     med_name varchar,
     med_description text,

--- a/policy/manager_insert_medicine.sql
+++ b/policy/manager_insert_medicine.sql
@@ -1,0 +1,12 @@
+CREATE POLICY "manager_can_insert_medicine"
+ON Medicine
+FOR INSERT
+USING (
+    EXISTS (
+        SELECT 1
+        FROM staff s
+        WHERE s.account_uid = auth.uid()
+        AND s.status = true
+        AND s.role IN ('manager', 'admin')
+    )
+);

--- a/policy/manager_update_medicine.sql
+++ b/policy/manager_update_medicine.sql
@@ -1,0 +1,12 @@
+CREATE POLICY "manager_can_update_medicine"
+ON Medicine
+FOR UPDATE
+USING (
+    EXISTS (
+        SELECT 1
+        FROM staff s
+        WHERE s.account_uid = auth.uid()
+        AND s.status = true
+        AND s.role IN ('manager', 'admin')
+    )
+);

--- a/policy/staff_update_ticket.sql
+++ b/policy/staff_update_ticket.sql
@@ -1,11 +1,12 @@
 CREATE POLICY "staff_can_update_ticket" 
 ON public.ticket
-FOR UPDATE
+FOR UPDATE 
+TO authenticated
 USING (
-    EXISTS (
-        SELECT 1 
-        FROM staff s
-        WHERE s.staff_id = auth.uid() 
-        AND s.status = true
+    assigned_to IN (
+        SELECT staff_id 
+        FROM staff 
+        WHERE account_uid = auth.uid() 
+        AND status = true
     )
 );

--- a/policy/staff_update_ticket.sql
+++ b/policy/staff_update_ticket.sql
@@ -1,11 +1,11 @@
-CREATE POLICY "staff_can_update_ticket" ON public.ticket
-FOR UPDATE 
-TO authenticated
+CREATE POLICY "staff_can_update_ticket" 
+ON public.ticket
+FOR UPDATE
 USING (
-    assigned_to IN (
-        SELECT staff_id 
-        FROM staff 
-        WHERE account_uid = auth.uid() 
-        AND status = true
+    EXISTS (
+        SELECT 1 
+        FROM staff s
+        WHERE s.staff_id = auth.uid() 
+        AND s.status = true
     )
 );


### PR DESCRIPTION

This PR is linked with issue #28 

## What? 
This PR added 4 requested functions `get_medicine`, `delete_medicine`, `update_medicine`, `add_medicine` and policies  `manager_can_update_medicine`, `manager_can_insert_medicine` to regulate who can delete or update medication.

## Why?
- The new functions enable CRUD operations for the Medicine table.
- The policy restricts INSERT and UPDATE operations to active managers and admins.

## How?
- Added four functions: `add_medication` (returns void), `delete_medication` (soft-deletes by setting is_available to FALSE, returns void), `get_medication_info` (returns medication details as JSON), and `update_medication` (returns void).
- Created the `manager_can_update_medicine` and `manager_can_insert_medicine` policy to restrict INSERT and UPDATE on the Medicine table to active managers and admins, using account_id and auth.id().