### PR TITLE
[refactor] ID Unification, function call parameters renaming.

### DIFF
--- a/fns/create_ticket.sql
+++ b/fns/create_ticket.sql
@@ -1,0 +1,44 @@
+CREATE FUNCTION "public"."create_ticket" (
+  "p_title" "text",
+  "p_content" "text",
+  "p_type" "public"."ticket_type"
+) RETURNS "uuid" LANGUAGE "plpgsql" AS $$
+DECLARE
+  free_staff_user_id uuid;
+BEGIN
+  -- Select a staff member with the least assigned tickets
+  -- This assumes 'assigned_to' in 'ticket' refers to user_id (auth.users.id)
+  SELECT t.assigned_to, count(t.assigned_to) c
+  INTO free_staff_user_id
+  FROM public.ticket t
+  GROUP BY t.assigned_to
+  ORDER BY c ASC
+  LIMIT 1; -- Changed to LIMIT 1 as you want one staff member
+
+  IF free_staff_user_id IS NULL THEN
+    -- Fallback if no staff is assigned any tickets yet, assign to an arbitrary staff
+    SELECT user_id INTO free_staff_user_id FROM public.staffs LIMIT 1;
+    IF free_staff_user_id IS NULL THEN
+        RAISE EXCEPTION 'No staff members found to assign the ticket.';
+    END IF;
+  END IF;
+
+  RETURN public.create_ticket(p_title, p_content, p_type, free_staff_user_id);
+END;
+$$;
+
+-- Name: create_ticket("text", "text", "public"."ticket_type", "uuid"); Type: FUNCTION; Schema: public; Owner: -
+CREATE FUNCTION "public"."create_ticket" (
+  "p_title" "text",
+  "p_content" "text",
+  "p_type" "public"."ticket_type",
+  "p_assigned_to" "uuid"
+) RETURNS "uuid" LANGUAGE "plpgsql" AS $$
+DECLARE
+  new_id uuid = gen_random_uuid();
+BEGIN
+  INSERT INTO public.ticket (ticket_id, assigned_to, content, title, ticket_type, created_by)
+  VALUES (new_id, p_assigned_to, p_content, p_title, p_type, auth.uid());
+  RETURN new_id;
+END;
+$$;

--- a/fns/dimiss_ticket.sql
+++ b/fns/dimiss_ticket.sql
@@ -1,21 +1,24 @@
 -- Function: dismiss_ticket
 CREATE OR REPLACE FUNCTION public.dismiss_ticket(
-    ticket_id UUID,
-    note TEXT
+    p_ticket_id UUID,
+    p_note TEXT
 )
 RETURNS VOID AS $$
-DECLARE
 
-    ticket_exists BOOLEAN;
 BEGIN
     -- Update the ticket status
     UPDATE ticket 
     SET status = 'canceled'::tik_status 
-    WHERE ticket.ticket_id = dismiss_ticket.ticket_id;
+    WHERE ticket.ticket_id = p_ticket_id;
     
     -- Update related appointments
     UPDATE appointment 
     SET status = 'canceled'::apt_status 
-    WHERE appointment.ticket_id = dismiss_ticket.ticket_id;
+    WHERE appointment.ticket_id = p_ticket_id;
+
+    -- Log the dismissal
+    INSERT INTO public.ticket_interaction_history (ticket_id, action, note)
+    VALUES (p_ticket_id, 'cancel'::public.ticket_interaction_type, p_note);
+
 END;
 $$ LANGUAGE plpgsql;

--- a/fns/edit_interaction_history.sql
+++ b/fns/edit_interaction_history.sql
@@ -1,11 +1,11 @@
 CREATE OR REPLACE FUNCTION edit_interaction_history(
-    uid integer,
-    note text
+    p_id integer,
+    p_note text
 )
 RETURNS VOID AS $$
 BEGIN
     UPDATE ticket_interaction_history history
-    SET history.note = note
-    WHERE history.id = uid;
+    SET history.note = p_note
+    WHERE history.id = p_id;
 END;
 $$ LANGUAGE plpgsql;

--- a/fns/forward_ticket.sql
+++ b/fns/forward_ticket.sql
@@ -1,4 +1,4 @@
-Create or replace function forward_ticket(ticket_id uuid, from_staff uuid, to_staff uuid)
+Create or replace function forward_ticket(p_ticket_id uuid, from_staff uuid, to_staff uuid)
 returns void as $$
 begin
 insert into public.ticket_interaction_history (ticket_id, action, note, by) VALUES (ticket_id, 'forward', 'Forwarded from ' || from_staff || ' to ' || to_staff, auth.uid());

--- a/fns/get_account_details.sql
+++ b/fns/get_account_details.sql
@@ -1,0 +1,27 @@
+CREATE OR REPLACE FUNCTION "public"."get_account_details" ("p_id" "uuid") RETURNS "jsonb" LANGUAGE "plpgsql" SECURITY DEFINER AS $$
+DECLARE
+  user_details_info jsonb;
+  staff_info jsonb;
+  auth_details jsonb;
+BEGIN
+  -- Get details from user_details
+  SELECT to_jsonb(ud)
+  INTO user_details_info
+  FROM public.user_details ud
+  WHERE ud.user_id = p_id;
+
+  -- Get staff-specific details if applicable
+  SELECT to_jsonb(s)
+  INTO staff_info
+  FROM public.staffs s
+  WHERE s.user_id = p_id;
+
+  -- Get auth.users details
+  SELECT to_jsonb(r)
+  INTO auth_details
+  FROM (SELECT email, phone FROM auth.users WHERE id = p_id) r;
+
+  -- Combine all information. staff_info will be undefined if not a staff.
+  RETURN user_details_info || jsonb_build_object('staff_info', staff_info) || auth_details;
+END;
+$$;

--- a/fns/get_all_tickets.sql
+++ b/fns/get_all_tickets.sql
@@ -1,0 +1,30 @@
+CREATE OR REPLACE FUNCTION "public"."get_all_tickets" () RETURNS "json" LANGUAGE "plpgsql" AS $$
+DECLARE
+  content JSON;
+BEGIN
+
+  SELECT
+    json_agg(q) INTO content
+  FROM
+    (
+      SELECT
+        tx.*,
+        latest.last_interacted_on
+      FROM
+        public.ticket tx
+        LEFT JOIN (
+          SELECT
+            ticket_id,
+            MAX(time) as last_interacted_on
+          FROM
+            public.ticket_interaction_history ti
+          GROUP BY
+            ticket_id
+        ) latest ON tx.ticket_id = latest.ticket_id
+    ) q
+  WHERE
+    q.assigned_to = auth.uid();
+
+  RETURN COALESCE(content, '[]'::json);
+END;
+$$;

--- a/fns/get_display_name.sql
+++ b/fns/get_display_name.sql
@@ -1,0 +1,15 @@
+CREATE OR REPLACE FUNCTION "public"."get_display_name" ("p_id" "uuid") RETURNS "text" LANGUAGE "plpgsql" AS $$
+DECLARE
+    display_name TEXT;
+BEGIN
+    SELECT full_name
+    INTO display_name
+    FROM public.user_details
+    WHERE user_id = p_id;
+
+    IF display_name IS NULL THEN
+        RETURN public.get_random_name();
+    END IF;
+    RETURN display_name;
+END;
+$$

--- a/fns/get_doctor_schedule.sql
+++ b/fns/get_doctor_schedule.sql
@@ -1,40 +1,29 @@
-create or  replace function get_doctor_schedule_with_date(date_required date)
-returns json as
-$$
-declare json_result json;
-begin
--- start return the json
-select jsonb_agg(   
-    /*
-    Note: about the store type of jsonb_agg()* and  json_agg()**
-    (*) store type is binary and it's arrange the field alphabetically, remove whitespaces and normalize number (eg: select '{"count": 01.00}'::json the result will be {"count":1.0})
-    (**) store type is text, it's preserve any format and does not remove whitespaces, number will not be normalize (eg: select '{"count": 01.00}'::json the result will be {"count":01.00})
-    These differences only affect back-end's queries.
-    */
+-- Name: get_doctor_schedule_with_date("date"); Type: FUNCTION; Schema: public; Owner: -
+CREATE FUNCTION "public"."get_doctor_schedule_with_date" ("date" "date") RETURNS "jsonb" LANGUAGE "plpgsql" AS $$
+DECLARE
+  current_user_id UUID;
+  result JSONB;
+BEGIN
+  -- Get the user ID for the currently authenticated user
+  SELECT auth.uid() INTO current_user_id;
+
+  IF NOT EXISTS (SELECT 1 FROM public.staffs WHERE user_id = current_user_id) THEN
+    RAISE EXCEPTION 'Current user is not a staff member.';
+  END IF;
+
+  -- Build and return the aggregated JSONB schedule
+  SELECT jsonb_agg(
+    to_jsonb(tap) ||
     jsonb_build_object(
-    'meeting_date', apt.meeting_date,
-    'duration', apt.duration,
-    'status', apt.status,
-    'content', apt.content,
-    'patient_information', jsonb_build_object(
-        'uuid', pt.patient_uid,
-        'account_uid', ad.account_uid,
-        'full_name', concat(ad.first_name,' ', ad.last_name),--this will return null if either first or last name is null
-        'dob', ad.dob,
-        'profile_picrure', ad.profile_picture,
-        'account_type', ad.account_type
-    ),
-    'ticket_id', ti.ticket_id
+      'patient_info', to_jsonb(ud_patient)
+    )
+  )
+  INTO result
+  FROM public.appointment tap
+  JOIN public.user_details ud_patient ON tap.patient_id = ud_patient.user_id
+  WHERE tap.meeting_date::date = date
+    AND tap.staff_id = current_user_id; -- Assuming staff_id in appointment is the user_id of the staff
 
-)
-) into json_result
-
-    from appointment apt
-    join ticket ti on ti.assigned_to = apt.staff_id
-    join patient pt on pt.patient_uid = apt.patient_uid
-    join accountdetails ad on ad.account_uid = apt.staff_id
-    where apt.meeting_date = date_required;
-
-    return json_result;
-end;
-$$ language plpgsql;
+  RETURN COALESCE(result, '[]'::jsonb); -- Ensure empty array if no results
+END;
+$$;

--- a/fns/get_ticket_details.sql
+++ b/fns/get_ticket_details.sql
@@ -1,0 +1,37 @@
+CREATE FUNCTION "public"."get_ticket_details" ("tid" "uuid") RETURNS "json" LANGUAGE "plpgsql" AS $$
+DECLARE
+  content JSON;
+  history JSON;
+  apt JSON;
+  result JSON;
+BEGIN
+  -- Fetch the ticket data
+  SELECT
+    to_jsonb(tic) || jsonb_build_object(
+      'created_by', get_account_details(tic.created_by)
+    ) AS result
+  INTO content
+  FROM public.ticket tic
+  WHERE ticket_id = tid;
+
+  SELECT json_agg(
+    to_jsonb(tih) || jsonb_build_object(
+        'by', get_account_details(tih.by)
+    )
+  ) INTO history
+  FROM public.ticket_interaction_history tih
+  WHERE ticket_id = tid;
+
+  SELECT json_agg(appointment) INTO apt
+  FROM public.appointment
+  WHERE appointment.ticket_id = tid;
+
+  result := json_build_object(
+    'ticket', content,
+    'interactions', COALESCE(history, '[]'::json),
+    'appointments', COALESCE(apt, '[]'::json)
+  );
+
+  RETURN result;
+END;
+$$;

--- a/fns/modify_ticket.sql
+++ b/fns/modify_ticket.sql
@@ -1,12 +1,14 @@
-create or replace function modify_ticket(ticket_id_to_mod uuid, new_content text, new_title text)
-returns void as 
-
-$$
+create
+or replace function modify_ticket (
+    p_ticket_id uuid,
+    new_content text,
+    new_title text
+) returns void as $$
 begin
     update Ticket t
     set content = new_content,
         title = new_title
-        where t.ticket_id = ticket_id_to_mod;
+        where t.ticket_id = ticket_id;
+    INSERT INTO ticket_interaction_history (ticket_id, action)VALUES (p_ticket_id, 'edit'::ticket_interaction_type);
 end;
-$$
-language plpgsql;
+$$ language plpgsql;

--- a/fns/query_account_info.sql
+++ b/fns/query_account_info.sql
@@ -1,13 +1,20 @@
 CREATE OR REPLACE FUNCTION query_account_information(_offset integer, _limit integer, query text) 
 returns json as $$
-DECLARE
-    res json
-BEGIN  
-SELECT json_agg(ad) FROM accountdetails ad INTO res WHERE  first_name LIKE "%"||query||"%" 
-                                    OR last_name LIKE "%"||query||"%" 
-                                    OR account_type LIKE "%"||query||"%" 
-LIMIT _limit OFFSET _offset;
-RETURN json_build_object(
-    'users', res
-);
+DECLARE 
+    res JSON;
+    pat TEXT;
+BEGIN
+    pat := '%' || query || '%';
+
+    SELECT json_agg(ud)
+    FROM user_details ud INTO res
+    WHERE
+        full_name ILIKE pat
+        OR array_to_string(roles::text[], '') ILIKE pat
+    LIMIT _limit
+    OFFSET _offset;
+
+    RETURN COALESCE(res, '[]'::JSON);
 END;
+$$;
+-- By @The3dit0r

--- a/fns/spawn_ticket.sql
+++ b/fns/spawn_ticket.sql
@@ -9,6 +9,7 @@ end;
 $$ language plpgsql;
 -----------------------------------------------------------------------------------
 -- a second function incase staffs wants to get log  or want to take ticket uuid for further uses
+-- 
 create or replace function spawn_ticket_with_noti_and_id_returned(f_assigned_to uuid, f_content text )
 return uuid as $$
 declare

--- a/fns/update_appointment_content.sql
+++ b/fns/update_appointment_content.sql
@@ -1,7 +1,5 @@
-create or replace function update_appointment_content(id_to_update uuid, new_content text)
-returns void as 
-
-$$
+create
+or replace function update_appointment_content (id_to_update uuid, new_content text) returns void as $$
 declare 
     temp_ticket_id uuid;
 begin
@@ -15,14 +13,11 @@ begin
     where apt.appointment_id = id_to_update
     into temp_ticket_id;
 --update corresponding ticket interaction history
-    insert into Ticket_interaction_history(ticket_id, time, action, note, "by")
+    insert into Ticket_interaction_history(ticket_id, action, note)
     values (
         temp_ticket_id,
-        now(),
         'appointment_update',
-        format('Updated appointment id: %s  with new content: %s', id_to_update::text, new_content),  -- format note for readability
-        auth.uid()                                                 -- this takes the id of the logged in user who is the modifier
+        format('Updated appointment id: %s  with new content: %s', id_to_update::text, new_content)  -- format note for readability
     );
 end;
-$$
-language plpgsql;
+$$ language plpgsql;

--- a/fns/update_appointment_doctor.sql
+++ b/fns/update_appointment_doctor.sql
@@ -15,13 +15,11 @@ BEGIN
     SET apt.staff_id = staff_id
     WHERE apt.appointment_id = id;
 
-    INSERT INTO ticket_interaction_history (ticket_id, time, action, note, by)
+    INSERT INTO ticket_interaction_history (ticket_id, action, note)
     VALUES (
         ticket_id_temp, 
-        now(),
         'appointment_update'::ticket_interaction_type, 
-        'Doctor update changed from ' || old_staff_id || ' to ' || staff_id || ' for appointment ' || id, 
-        auth.uid()
+        'Doctor update changed from ' || old_staff_id || ' to ' || staff_id || ' for appointment ' || id
     );
 END;
 $$ LANGUAGE plpgsql;

--- a/fns/update_appointment_duration.sql
+++ b/fns/update_appointment_duration.sql
@@ -15,13 +15,11 @@ begin
     where apt.appointment_id = id_to_update
     into temp_ticket_id;
 --update corresponding ticket interaction history
-    insert into Ticket_interaction_history(ticket_id, time, action, note, "by")
+    insert into Ticket_interaction_history(ticket_id, action, note)
     values (
         temp_ticket_id,
-        now(),
         'appointment_update',
-        format('Updated appointment id: %s  with new duration: %s', id_to_update::text, new_duration),    -- format for readability
-        auth.uid()                                                      -- this takes id from user who logged in
+        format('Updated appointment id: %s  with new duration: %s', id_to_update::text, new_duration)    -- format for readability
     );
 end;
 $$

--- a/fns/update_appointment_status.sql
+++ b/fns/update_appointment_status.sql
@@ -1,8 +1,5 @@
-CREATE OR REPLACE FUNCTION update_appointment_status(
-    id uuid,
-    status apt_status
-)
-RETURNS VOID AS $$
+CREATE
+OR REPLACE FUNCTION update_appointment_status (id uuid, status apt_status) RETURNS VOID AS $$
 DECLARE 
     ticket_id_temp uuid;
     old_status apt_status;
@@ -15,13 +12,11 @@ BEGIN
     SET apt.status = status
     WHERE apt.appointment_id = id;
 
-    INSERT INTO ticket_interaction_history (ticket_id, time, action, note, by)
+    INSERT INTO ticket_interaction_history (ticket_id, action, note)
     VALUES (
-        ticket_id_temp, 
-        now(),
-        'appointment_update'::ticket_interaction_type, 
-        'Status update changed from ' || old_status || ' to ' || status || ' for appointment ' || id, 
-        auth.uid()
+        ticket_id_temp,
+              'appointment_update'::ticket_interaction_type, 
+        'Status update changed from ' || old_status || ' to ' || status || ' for appointment ' || id
     );
 END;
 $$ LANGUAGE plpgsql;

--- a/fns/update_appointment_time.sql
+++ b/fns/update_appointment_time.sql
@@ -15,13 +15,11 @@ returns void as
     where apt.appointment_id = id_to_update
     into temp_ticket_id;
 --update corresponding ticket interaction history
-    insert into Ticket_interaction_history(ticket_id, time, action, note, "by")
+    insert into Ticket_interaction_history(ticket_id, action, note)
     values (
         temp_ticket_id,
-        now(),
         'appointment_update',
-        format('Updated appointment id: %s  with new meeting time: %L', id_to_update::text, new_meeting_time),
-        auth.uid()
+        format('Updated appointment id: %s  with new meeting time: %L', id_to_update::text, new_meeting_time)
     );
 end;
  $$

--- a/fns/update_appointment_visibility.sql
+++ b/fns/update_appointment_visibility.sql
@@ -14,13 +14,11 @@ BEGIN
     SET apt.visibility = isPublic
     WHERE apt.appointment_id = id;
 
-    INSERT INTO ticket_interaction_history (ticket_id, time, action, note, by)
+    INSERT INTO ticket_interaction_history (ticket_id, action, note)
     VALUES (
         ticket_id_temp, 
-        now(),
         'appointment_update'::ticket_interaction_type, 
-        'Visibility update changed to ' || status || ' for appointment ' || id, 
-        auth.uid()
+        'Visibility update changed to ' || status || ' for appointment ' || id
     );
 END;
 $$ LANGUAGE plpgsql;

--- a/fns/update_ticket_status.sql
+++ b/fns/update_ticket_status.sql
@@ -1,8 +1,5 @@
-CREATE OR REPLACE FUNCTION public.update_ticket_status(
-    ticket_id UUID,
-    new_status ticket_status
-)
-RETURNS VOID AS $$
+CREATE
+OR REPLACE FUNCTION public.update_ticket_status (ticket_id UUID, new_status ticket_status) RETURNS VOID AS $$
 DECLARE
     current_status ticket_status;
     update_count INTEGER;
@@ -18,12 +15,11 @@ BEGIN
     WHERE ticket.ticket_id = updateTicketStatus.ticket_id;
     
     -- Logs the change
-    INSERT INTO ticket_interaction_history (ticket_id, action, note, by)
+    INSERT INTO ticket_interaction_history (ticket_id, action, note)
     VALUES (
         updateTicketStatus.ticket_id, 
         'processed'::ticket_interaction_type,
-        'Status changed from ' || current_status || ' to ' || new_status, 
-        auth.uid()
+        'Status changed from ' || current_status || ' to ' || new_status
     );
 END;
 $$ LANGUAGE plpgsql;

--- a/schema/create_tables.sql
+++ b/schema/create_tables.sql
@@ -1,3 +1,94 @@
+--
+-- Name: account_type; Type: TYPE; Schema: public; Owner: -
+--
+CREATE TYPE "public"."account_type" AS ENUM('staff', 'patient');
+
+--
+-- Name: TYPE "account_type"; Type: COMMENT; Schema: public; Owner: -
+--
+COMMENT ON
+TYPE "public"."account_type" IS 'This discerns between Staffs and user account';
+
+--
+-- Name: appointment_status; Type: TYPE; Schema: public; Owner: -
+--
+CREATE TYPE "public"."appointment_status" AS ENUM(
+  'pending',
+  'scheduled',
+  'in_progress',
+  'completed',
+  'canceled',
+  'no_show'
+);
+
+--
+-- Name: medicine_timing; Type: TYPE; Schema: public; Owner: -
+--
+CREATE TYPE "public"."medicine_timing" AS ENUM(
+  'empty stomach',
+  'before meal',
+  'with meal',
+  'after meal'
+);
+
+--
+-- Name: role; Type: TYPE; Schema: public; Owner: -
+--
+CREATE TYPE "public"."role" AS ENUM(
+  'customer',
+  'staff',
+  'doctor',
+  'manager',
+  'administrator'
+);
+
+--
+-- Name: staff_role; Type: TYPE; Schema: public; Owner: -
+--
+CREATE TYPE "public"."staff_role" AS ENUM('doctor', 'staff', 'manager', 'admin');
+
+--
+-- Name: ticket_interaction_type; Type: TYPE; Schema: public; Owner: -
+--
+CREATE TYPE "public"."ticket_interaction_type" AS ENUM(
+  'create',
+  'forward',
+  'cancel',
+  'approve',
+  'other',
+  'comment',
+  'appointment_update',
+  'edit'
+);
+
+--
+-- Name: TYPE "ticket_interaction_type"; Type: COMMENT; Schema: public; Owner: -
+--
+COMMENT ON
+TYPE "public"."ticket_interaction_type" IS 'This denotes what was done to the ticket.';
+
+--
+-- Name: ticket_status; Type: TYPE; Schema: public; Owner: -
+--
+CREATE TYPE "public"."ticket_status" AS ENUM('pending', 'cancelled', 'approved');
+
+--
+-- Name: TYPE "ticket_status"; Type: COMMENT; Schema: public; Owner: -
+--
+COMMENT ON
+TYPE "public"."ticket_status" IS 'Tickets are units of work for staffs to process, it can be related to company''s operations like appointments, tests, database requests,.. etc. It can be of 3 statuses: pending - The ticket is currently being processed, cancelled - The ticket was cancelled (Unsuccessful), approved - The ticket was approved (Successful)';
+
+--
+-- Name: ticket_type; Type: TYPE; Schema: public; Owner: -
+--
+CREATE TYPE "public"."ticket_type" AS ENUM('appointment', 'test', 'other');
+
+--
+-- Name: TYPE "ticket_type"; Type: COMMENT; Schema: public; Owner: -
+--
+COMMENT ON
+TYPE "public"."ticket_type" IS 'This is possible ticket types';
+
 CREATE TABLE
   public.appointment (
     appointment_id uuid NOT NULL DEFAULT gen_random_uuid (),

--- a/schema/create_tables.sql
+++ b/schema/create_tables.sql
@@ -1,190 +1,184 @@
---create the uuid random generate extension, (we had it installed but i'm doing it for asurance ;))
---create extension if not exist "pgcrypto";
------------------------------------
--- account table 
-create table AccountDetails(-- contains basic information of an account
-  account_uid uuid references auth.users(id) on delete cascade,
-  first_name varchar(50), -- can be null and dummy name is auto-generated
-  last_name varchar(50), -- can be null and dummy name is auto-generated
-  dob date, -- can be null
-  profile_picrure text, -- can be null
-  primary key (account_uid)
-);
------------------------------------
---patient table
-create table Patient(
-  patient_uid uuid primary key default gen_random_uuid(), 
-  account_uid uuid,
-  anonymous_status boolean default true, -- when a patient has an account, can be use to set visibility of patient information
-  foreign key (account_uid) references auth.users(id)
-);
------------------------------------
---staff table
-create table Staff(
-  staff_id uuid primary key default gen_random_uuid(),
-  account_uid uuid,
-  foreign key (account_uid) references auth.users(id),
-  role varchar(20),
-  join_date date,
-  status boolean  
-);
------------------------------------
---enum for status ticket/appointment
-create type tik_status as enum('pending','booked', 'closed', 'canceled');
-create type apt_status as enum('pending', 'scheduled', 'in progress', 'completed', 'canceled','no show');
-create type ticket_type as enum('appointment', 'test', 'other');
---ticket table
-create table Ticket(
-  ticket_id uuid primary key default gen_random_uuid(),
-  assigned_to uuid references Staff(staff_id),
-  date_created timestamptz,
-  ticket_type ticket_type,
-  content text,
-  status tik_status default 'pending'
-);
------------------------------------
---appointment table
-create table Appointment(
-  appointment_id uuid primary key default gen_random_uuid(),
-  staff_id uuid,
-  ticket_id uuid,
-  patient_uid uuid,
-  foreign key (staff_id) references Staff(staff_id), 
-  foreign key (ticket_id) references Ticket(ticket_id),
-  foreign key (patient_uid) references Patient(patient_uid),
-  created_date date,
-  meeting_date date,
-  content text,
-  visibility boolean,
-  status apt_status default 'pending'
-);
------------------------------------
---Doctor specification 
-create table Specification(
-  specification_id uuid primary key default gen_random_uuid(),
-  name varchar(50),
-  achieved_date date,
-  level integer
-);
--- create type week_day as enum ('Monday','Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday');
--- create type session_day as enum ('Morning', 'Afternoon', 'Evening', 'Midnight');
+CREATE TABLE
+  public.appointment (
+    appointment_id uuid NOT NULL DEFAULT gen_random_uuid (),
+    staff_id uuid,
+    ticket_id uuid,
+    patient_id uuid,
+    created_date timestamp with time zone DEFAULT (now() AT TIME ZONE 'utc'::text),
+    meeting_date timestamp with time zone,
+    content text,
+    visible boolean NOT NULL DEFAULT false,
+    status USER - DEFINED DEFAULT 'pending'::appointment_status,
+    duration smallint NOT NULL DEFAULT '30'::smallint,
+    CONSTRAINT appointment_pkey PRIMARY KEY (appointment_id),
+    CONSTRAINT appointment_staff_id_fkey FOREIGN KEY (staff_id) REFERENCES auth.users (id),
+    CONSTRAINT appointment_ticket_id_fkey FOREIGN KEY (ticket_id) REFERENCES public.ticket (ticket_id),
+    CONSTRAINT appointment_patient_id_fkey FOREIGN KEY (patient_id) REFERENCES auth.users (id)
+  );
 
-create table DoctorSpecification(
-  staff_id uuid,
-  specification_id uuid,
-  foreign key (staff_id) references Staff(staff_id),
-  foreign key (specification_id)references Specification(specification_id),
-  primary key (staff_id, specification_id)
-);
------------------------------------
---doctor schedule
-create table DaySession(
-  day_session varchar(20) primary key default gen_random_uuid(),
-  start_time time,
-  end_time time,
-  location varchar(50),
-  status boolean -- true for Available and false for Busy
-);
-create table WeekDay(
-  day_of_week varchar(20),
-  day_session varchar(20),
-  primary key(day_of_week, day_session),
-  foreign key(day_session) references DaySession(day_session)
-);
-create table DoctorSchedule(
-  staff_id uuid references Staff(staff_id),
-  day_of_week varchar(20),
-  day_session varchar(20),
-  primary key (staff_id, day_of_week, day_session),
-  foreign key (day_of_week, day_session) references WeekDay(day_of_week, day_session)
-);
------------------------------------
--- --regimen ascociated
-create type med_timing as enum ('empty stomach', 'before meal', 'with meal', 'after meal'); 
-/*
-explaination:
-1.empty stomach ->  at least 1hr before meal or ~2hr after meal
-2.before meal -> ~15-30min before meal
-3.with meal -> taken together when having meal
-4. after meal -> ~15-30min after a meal
-the enums can be compared as numbered (ex: empty stomach < before meal)
-*/
-create table Medicine(
-  medicine_id uuid primary key default gen_random_uuid(),
-  name varchar(50),
-  description text,
-  is_available boolean,
-  med_time med_timing
-);
------------------------------------
---prescription table
-create table Prescription(
-  prescription_id uuid primary key default gen_random_uuid(),
-  name varchar(50),
-  note text
-);
-create table PrescriptionDetail(
-  prescription_detail_id uuid primary key default gen_random_uuid(),
-  prescription_id uuid,
-  medicine_id uuid,
-  foreign key (prescription_id) references Prescription(prescription_id),
-  foreign key (medicine_id) references Medicine(medicine_id),
-  start_time timestamptz,
-  end_time timestamptz,
-  dosage float,
-  interval integer,
-  note text
-);
------------------------------------
--- customized regimen
-create table CustomizedRegimen(
-  cus_regimen_id uuid primary key default gen_random_uuid(),
-  name varchar(50),
-  description text,
-  create_time date
-);
-create table CustomizedRegimenDetail(
-  cus_regimen_detail_id uuid primary key default gen_random_uuid(),
-  cus_regimen_id uuid,
-  prescription_id uuid,
-  foreign key (cus_regimen_id) references CustomizedRegimen(cus_regimen_id),
-  foreign key (prescription_id) references Prescription(prescription_id),
-  start_date date,
-  end_date date,
-  total_dosage float,
-  frequency integer,
-  note text
-);
------------------------------------
--- original regimen
-create table Regimen(
-  regimen_id uuid primary key default gen_random_uuid(),
-  name varchar(50),
-  create_date date,
-  description text
-);
-create table RegimenDetail(
-  regimen_detail_id uuid primary key default gen_random_uuid(),
-  regimen_id uuid,
-  medicine_id uuid,
-  foreign key (regimen_id) references Regimen(regimen_id),
-  foreign key (medicine_id) references Medicine(medicine_id),
-  start_date date,
-  end_date date,
-  total_dosage float,
-  frequency integer,
-  note text
-);
------------------------------------
---patient medicine intake history
-create table IntakeHistory(
-  intake_id uuid primary key default gen_random_uuid(),
-  patient_uid uuid,
-  prescription_id uuid,
-  foreign key (patient_uid) references Patient(patient_uid),
-  foreign key (prescription_id) references Prescription(prescription_id),
-  take_time timestamptz,
-  missed boolean,
-  note text,
-  remind_inc_appointment boolean
-);
+CREATE TABLE
+  public.customizedregimen (
+    cus_regimen_id uuid NOT NULL DEFAULT gen_random_uuid (),
+    name character varying,
+    description text,
+    create_time date,
+    CONSTRAINT customizedregimen_pkey PRIMARY KEY (cus_regimen_id)
+  );
+
+CREATE TABLE
+  public.customizedregimendetail (
+    cus_regimen_detail_id uuid NOT NULL DEFAULT gen_random_uuid (),
+    cus_regimen_id uuid,
+    prescription_id uuid,
+    start_date date,
+    end_date date,
+    total_dosage double precision,
+    frequency integer,
+    note text,
+    CONSTRAINT customizedregimendetail_pkey PRIMARY KEY (cus_regimen_detail_id),
+    CONSTRAINT customizedregimendetail_prescription_id_fkey FOREIGN KEY (prescription_id) REFERENCES public.prescriptions (prescription_id),
+    CONSTRAINT customizedregimendetail_cus_regimen_id_fkey FOREIGN KEY (cus_regimen_id) REFERENCES public.customizedregimen (cus_regimen_id)
+  );
+
+CREATE TABLE
+  public.intakehistory (
+    intake_id uuid NOT NULL DEFAULT gen_random_uuid (),
+    patient_uid uuid,
+    prescription_id uuid,
+    take_time timestamp with time zone,
+    missed boolean,
+    note text,
+    remind_inc_appointment boolean,
+    CONSTRAINT intakehistory_pkey PRIMARY KEY (intake_id),
+    CONSTRAINT intakehistory_prescription_id_fkey FOREIGN KEY (prescription_id) REFERENCES public.prescriptions (prescription_id)
+  );
+
+CREATE TABLE
+  public.medicines (
+    medicine_id uuid NOT NULL DEFAULT gen_random_uuid (),
+    name character varying,
+    description text,
+    is_available boolean,
+    med_time USER - DEFINED,
+    CONSTRAINT medicines_pkey PRIMARY KEY (medicine_id)
+  );
+
+CREATE TABLE
+  public.prescription_details (
+    prescription_detail_id uuid NOT NULL DEFAULT gen_random_uuid (),
+    prescription_id uuid,
+    medicine_id uuid,
+    start_time timestamp with time zone,
+    end_time timestamp with time zone,
+    dosage double precision,
+    interval integer,
+    note text,
+    CONSTRAINT prescription_details_pkey PRIMARY KEY (prescription_detail_id),
+    CONSTRAINT prescriptiondetail_medicine_id_fkey FOREIGN KEY (medicine_id) REFERENCES public.medicines (medicine_id),
+    CONSTRAINT prescriptiondetail_prescription_id_fkey FOREIGN KEY (prescription_id) REFERENCES public.prescriptions (prescription_id)
+  );
+
+CREATE TABLE
+  public.prescriptions (
+    prescription_id uuid NOT NULL DEFAULT gen_random_uuid (),
+    name character varying,
+    note text,
+    CONSTRAINT prescriptions_pkey PRIMARY KEY (prescription_id)
+  );
+
+CREATE TABLE
+  public.random_name_pool (
+    id integer NOT NULL DEFAULT nextval('random_name_pool_id_seq'::regclass),
+    name text NOT NULL,
+    CONSTRAINT random_name_pool_pkey PRIMARY KEY (id)
+  );
+
+CREATE TABLE
+  public.regimen_details (
+    regimen_detail_id uuid NOT NULL DEFAULT gen_random_uuid (),
+    regimen_id uuid,
+    medicine_id uuid,
+    start_date date,
+    end_date date,
+    total_dosage double precision,
+    frequency integer,
+    note text,
+    CONSTRAINT regimen_details_pkey PRIMARY KEY (regimen_detail_id),
+    CONSTRAINT regimendetail_medicine_id_fkey FOREIGN KEY (medicine_id) REFERENCES public.medicines (medicine_id),
+    CONSTRAINT regimendetail_regimen_id_fkey FOREIGN KEY (regimen_id) REFERENCES public.regimens (regimen_id)
+  );
+
+CREATE TABLE
+  public.regimens (
+    regimen_id uuid NOT NULL DEFAULT gen_random_uuid (),
+    name character varying,
+    create_date date,
+    description text,
+    CONSTRAINT regimens_pkey PRIMARY KEY (regimen_id)
+  );
+
+CREATE TABLE
+  public.specification_ownerships (
+    staff_id uuid NOT NULL,
+    specification_id uuid NOT NULL,
+    CONSTRAINT specification_ownerships_pkey PRIMARY KEY (staff_id, specification_id),
+    CONSTRAINT specification_ownerships_specification_id_fkey FOREIGN KEY (specification_id) REFERENCES public.specifications_types (specification_id),
+    CONSTRAINT specification_ownerships_staff_id_fkey FOREIGN KEY (staff_id) REFERENCES public.staffs (user_id)
+  );
+
+CREATE TABLE
+  public.specifications_types (
+    specification_id uuid NOT NULL DEFAULT gen_random_uuid (),
+    name text,
+    description text,
+    CONSTRAINT specifications_types_pkey PRIMARY KEY (specification_id)
+  );
+
+CREATE TABLE
+  public.staffs (
+    user_id uuid NOT NULL,
+    join_date date NOT NULL DEFAULT (now())::date,
+    is_active boolean NOT NULL DEFAULT true,
+    leave_date date,
+    CONSTRAINT staffs_pkey PRIMARY KEY (user_id),
+    CONSTRAINT staffs_user_id_fkey FOREIGN KEY (user_id) REFERENCES auth.users (id)
+  );
+
+CREATE TABLE
+  public.ticket (
+    ticket_id uuid NOT NULL DEFAULT gen_random_uuid (),
+    assigned_to uuid,
+    date_created date DEFAULT now(),
+    content text,
+    title text,
+    ticket_type USER - DEFINED NOT NULL DEFAULT 'other'::ticket_type,
+    created_by uuid,
+    status USER - DEFINED NOT NULL DEFAULT 'pending'::ticket_status,
+    CONSTRAINT ticket_pkey PRIMARY KEY (ticket_id),
+    CONSTRAINT ticket_created_by_fkey FOREIGN KEY (created_by) REFERENCES auth.users (id),
+    CONSTRAINT ticket_assigned_to_fkey FOREIGN KEY (assigned_to) REFERENCES public.staffs (user_id)
+  );
+
+CREATE TABLE
+  public.ticket_interaction_history (
+    id bigint GENERATED ALWAYS AS IDENTITY NOT NULL UNIQUE,
+    ticket_id uuid NOT NULL,
+    time timestamp with time zone NOT NULL DEFAULT now(),
+    action USER - DEFINED NOT NULL DEFAULT 'other'::ticket_interaction_type,
+    note text,
+    by uuid DEFAULT auth.uid (),
+    CONSTRAINT ticket_interaction_history_pkey PRIMARY KEY (id),
+    CONSTRAINT ticket_interaction_history_by_fkey FOREIGN KEY (by) REFERENCES auth.users (id),
+    CONSTRAINT ticket_interaction_history_ticket_id_fkey FOREIGN KEY (ticket_id) REFERENCES public.ticket (ticket_id)
+  );
+
+CREATE TABLE
+  public.user_details (
+    user_id uuid NOT NULL,
+    full_name text NOT NULL DEFAULT get_random_name (),
+    birth_date date,
+    profile_image_url text,
+    roles ARRAY NOT NULL,
+    CONSTRAINT user_details_pkey PRIMARY KEY (user_id),
+    CONSTRAINT user_details_user_id_fkey FOREIGN KEY (user_id) REFERENCES auth.users (id)
+  );


### PR DESCRIPTION

## What?

Unified various user-related ID fields (`account_uid`, `patient_id`, `staff_id`) into a single consistent identifier: `user_id`. Also updated naming conventions across the codebase to align with the contributing guidelines.

## Why?

To reduce confusion, improve code clarity, and simplify logic related to user identification by consolidating multiple ID types into a unified `user_id`. This also ensures consistency with the project's naming standards and enhances maintainability.

## How?

* Replaced `account_uid`, `patient_id`, and `staff_id` with the standardized `user_id` where appropriate.
* Refactored function parameters, object keys, and database references accordingly.
* Renamed function calls and function call parameter naming for easier consumption of API.

