### PR TITLE
[feat] Add user details edit function and profile image policies

### DIFF
--- a/fns/edit_user_details.sql
+++ b/fns/edit_user_details.sql
@@ -1,0 +1,20 @@
+CREATE OR REPLACE FUNCTION edit_user_details(
+  p_user_id uuid,
+  p_full_name text,
+  p_birth_date date
+) 
+RETURNS BOOLEAN AS $$
+DECLARE
+  v_updated_count INTEGER;
+BEGIN
+  UPDATE user_details
+  SET 
+    full_name = COALESCE(p_full_name, full_name),
+    birth_date = COALESCE(p_birth_date, birth_date)
+  WHERE user_id = p_user_id;
+
+  GET DIAGNOSTICS v_updated_count = ROW_COUNT;
+
+  RETURN v_updated_count > 0;
+END;
+$$ LANGUAGE plpgsql;

--- a/policy/user_update_profile.sql
+++ b/policy/user_update_profile.sql
@@ -1,0 +1,20 @@
+-- View: anyone
+CREATE POLICY "Anyone can view profile images"
+ON storage.objects
+FOR SELECT
+USING (bucket_id = 'profile-images');
+
+CREATE POLICY "Anyone can upload profile images"
+ON storage.objects
+FOR INSERT
+WITH CHECK (bucket_id = 'profile-images');
+
+CREATE POLICY "Anyone can update profile images"
+ON storage.objects
+FOR UPDATE
+USING (bucket_id = 'profile-images');
+
+CREATE POLICY "Anyone can delete profile images"
+ON storage.objects
+FOR DELETE
+USING (bucket_id = 'profile-images');

--- a/policy/user_update_profile.sql
+++ b/policy/user_update_profile.sql
@@ -1,4 +1,3 @@
--- View: anyone
 CREATE POLICY "Anyone can view profile images"
 ON storage.objects
 FOR SELECT
@@ -9,12 +8,20 @@ ON storage.objects
 FOR INSERT
 WITH CHECK (bucket_id = 'profile-images');
 
-CREATE POLICY "Anyone can update profile images"
+CREATE POLICY "Users can update own profile images"
 ON storage.objects
 FOR UPDATE
-USING (bucket_id = 'profile-images');
+USING (
+  bucket_id = 'profile-images' 
+  AND auth.uid() IS NOT NULL
+  AND name LIKE '%' || auth.uid()::text || '%'
+);
 
-CREATE POLICY "Anyone can delete profile images"
+CREATE POLICY "Users can delete own profile images"
 ON storage.objects
 FOR DELETE
-USING (bucket_id = 'profile-images');
+USING (
+  bucket_id = 'profile-images' 
+  AND auth.uid() IS NOT NULL
+  AND name LIKE '%' || auth.uid()::text || '%'
+);

--- a/policy/user_update_profile.sql
+++ b/policy/user_update_profile.sql
@@ -11,17 +11,17 @@ WITH CHECK (bucket_id = 'profile-images');
 CREATE POLICY "Users can update own profile images"
 ON storage.objects
 FOR UPDATE
+TO authenticated
 USING (
   bucket_id = 'profile-images' 
-  AND auth.uid() IS NOT NULL
-  AND name LIKE '%' || auth.uid()::text || '%'
+  AND owner = auth.uid()
 );
 
 CREATE POLICY "Users can delete own profile images"
 ON storage.objects
 FOR DELETE
+TO authenticated
 USING (
   bucket_id = 'profile-images' 
-  AND auth.uid() IS NOT NULL
-  AND name LIKE '%' || auth.uid()::text || '%'
+  AND owner = auth.uid()
 );


### PR DESCRIPTION
## What?

Implemented the `edit_user_details` SQL function and created 4 new storage policies for the `profile-images` bucket.

* **Function: `edit_user_details`**

  * **Overview**: Updates user information in the `user_details` table to support and optimize the `updateUserProfile` Edge Function.
  * **Input**:

    ```sql
    p_user_id uuid,
    p_full_name text,
    p_birth_date date
    ```
  * **Output**: `Boolean`

* **4 New Policies**

  * **Overview**: Grants public access to view, upload, update, and delete profile images in the `profile-images` bucket.

## Why?

To let users update their profile information..

## How?

* Added a SQL RPC function `edit_user_details` for partial updates based on user input.
* Created 4 new RLS policies on the `profile-images` bucket to allow public operations: `select`, `insert`, `update`, and `delete`.
